### PR TITLE
allow_timeout is always considered True (or most of the time)

### DIFF
--- a/wifisetup/main.py
+++ b/wifisetup/main.py
@@ -71,7 +71,7 @@ network={
 
 
 def run_wifi(allow_timeout='True'):
-    client = WifiClient(bool(allow_timeout))
+    client = WifiClient(allow_timeout != 'False')
     client.join()
 
 


### PR DESCRIPTION
bool('False') is True, bool('True') is True, bool('') is False

No sure what the intended syntax is but as the input is a string I assume the counterpart of 'True' is 'False'