### PR TITLE
Refine text in the spoken dialog files

### DIFF
--- a/dialog/en-us/ap_cancel.dialog
+++ b/dialog/en-us/ap_cancel.dialog
@@ -1,2 +1,2 @@
-I've shut down the wifi network.
-The wifi network has been shut down.
+I've shut down the MYCROFT wifi network.
+The wifi network MYCROFT has been shut down.

--- a/dialog/en-us/ap_error.dialog
+++ b/dialog/en-us/ap_error.dialog
@@ -1,2 +1,2 @@
 I could not start up my wifi network. Please try rebooting.
-I couldn't start up my the wifi hardware. Please try rebooting.
+There was a problem starting my wifi hardware. Please try rebooting.

--- a/dialog/en-us/ap_up.dialog
+++ b/dialog/en-us/ap_up.dialog
@@ -1,2 +1,2 @@
-I've created a temporary wifi network.
-I've started up a temporary wifi network.
+I've created a temporary wifi network called MYCROFT.
+I've started a temporary wifi network named MYCROFT.

--- a/dialog/en-us/device.connected.dialog
+++ b/dialog/en-us/device.connected.dialog
@@ -1,2 +1,2 @@
-Open your browser and go to start dot mycroft dot A I.
-Open up a web browser and navigate to start dot mycroft dot A I.
+Follow the prompt on your mobile device or computer and choose a wifi network.  If you don't get a prompt, open your browser and go to start dot mycroft dot A I.
+Choose a wifi network on your mobile device or computer.  If you aren't automatically shown this page, open your browser and go to start dot mycroft dot A I to begin.


### PR DESCRIPTION
Subtle text changes, including going back to the prompt originally used by wifi setup.
It is slightly vague, be encompasses all of the different experiences seen when using
different devices and phones -- only some of which automatically open up the 
captive portal automatically.