### PR TITLE
Extend admin service to support NTP and reboots

### DIFF
--- a/mycroft_admin_service.py
+++ b/mycroft_admin_service.py
@@ -152,7 +152,7 @@ def system_update(client, data):
             package = "mycroft-picroft"
 
     call('apt-get update', shell=True)
-    call('apt-get install ' + package + ' -y', shell=True)
+    call(['apt-get', 'install', package, '-y'])
 
 
 def ssh_enable(*_):

--- a/wifisetup/main.py
+++ b/wifisetup/main.py
@@ -42,7 +42,8 @@ root.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler(sys.stderr)
 ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter(
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 root.addHandler(ch)
 


### PR DESCRIPTION
* Rename admin "mycroft." messagebus messages to "system." prefixes.  Now they
are:
    system.wifi.setup
    system.wifi.reset
    system.ssh.enable
    system.ssh.disable
  NOTE: Old messages still handled for backwards compat
* Add the following messages to the mycroft-admin service
    system.ntp.sync - forces an NTP clock synchronization
    system.reboot - triggers a system reboot
    system.shutdown - triggers a system shutdown
    system.update - triggers a mycroft-core/platform code upgrade
* Fix some PEP8 errors.
