### PR TITLE
Delete msm state files on RESET

### DIFF
--- a/mycroft_admin_service.py
+++ b/mycroft_admin_service.py
@@ -173,6 +173,8 @@ def reset_system(*_):
     rm -rf /opt/mycroft/skills/* &&
     mv /opt/mycroft/safety/skill-pairing /opt/mycroft/skills &&
     rm -rf /opt/mycroft/safety""", shell=True)
+    call("rm -rf /opt/mycroft/.skills-repo", shell=True)
+    call("rm -rf /home/mycroft/.mycroft/.mycroft-skills", shell=True)
     call([exe_file, 'wifi.reset'])
 
 


### PR DESCRIPTION
This includes the skills repo and the list of skills that has been setup. In case the .skills-repo becomes corrupted (as happened for Kathy) this is a sledge hammer that should be able to fix it.