### PR TITLE
Remove quotes from apt-get update command line

### DIFF
--- a/mycroft_admin_service.py
+++ b/mycroft_admin_service.py
@@ -143,8 +143,8 @@ def system_reboot(*_):
 
 
 def update_only_mycroft():
-    call(['apt-get', 'update', '-o', 'Dir::Etc::sourcelist="sources.list.d/repo.mycroft.ai.list"',
-          '-o', 'Dir::Etc::sourceparts="-"', '-o', 'APT::Get::List-Cleanup="0"'])
+    call(['apt-get', 'update', '-o', 'Dir::Etc::sourcelist=sources.list.d/repo.mycroft.ai.list',
+          '-o', 'Dir::Etc::sourceparts=-', '-o', 'APT::Get::List-Cleanup=0'])
 
 
 def get_core_version():


### PR DESCRIPTION
Found this in the logs for the admin service:
```
Reading package lists...
W: Unable to read /etc/apt/"-"/ - DirectoryExists (2: No such file or directory)
W: Unable to read /etc/apt/"sources.list.d/repo.mycroft.ai.list" - RealFileExists (2: No such file or directory)
```

I think quotes are normally expanded by the shell but in the invocation through subprocess they're not since it's not a shell resulting in errors finding the file.