### PR TITLE
fix 'Mycroft' utterance for mimic2

### DIFF
--- a/dialog/en-us/ap_cancel.dialog
+++ b/dialog/en-us/ap_cancel.dialog
@@ -1,2 +1,2 @@
-I've shut down the MYCROFT wifi network.
-The wifi network MYCROFT has been shut down.
+I've shut down the Mycroft wifi network.
+The wifi network Mycroft has been shut down.

--- a/dialog/en-us/ap_up.dialog
+++ b/dialog/en-us/ap_up.dialog
@@ -1,2 +1,2 @@
-I've created a temporary wifi network called MYCROFT.
-I've started a temporary wifi network named MYCROFT.
+I've created a temporary wifi network called Mycroft.
+I've started a temporary wifi network named Mycroft.

--- a/dialog/en-us/device.not.connected.dialog
+++ b/dialog/en-us/device.not.connected.dialog
@@ -1,2 +1,2 @@
-Use your mobile device or computer to connect to the wifi network 'MYCROFT'. Then enter the password 1 2 3 4 5 6 7 8
-Using your phone or computer, connect to the wifi called 'MYCROFT'. Then enter the password 1 2 3 4 5 6 7 8
+Use your mobile device or computer to connect to the wifi network 'Mycroft'. Then enter the password 1 2 3 4 5 6 7 8
+Using your phone or computer, connect to the wifi called 'Mycroft'. Then enter the password 1 2 3 4 5 6 7 8


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}
Mimic 2 distinctly reads out characters for an uppercase word
ex : MYCROFT as 'M', 'Y', 'C', 'R', 'O', 'F', 'T'
Listen to [this](https://mimic-api.mycroft.ai/synthesize?text=MYCROFT)
Corrected the dialog to handle the pronunciation in mimic2

* Description of how to validate or test this PR
  1. Set mimic2 as TTS for Mark1
  2. Setup wifi by pushing the top button on Mark1
  3. Mimic2 takes the utterance from [this](https://github.com/MycroftAI/mycroft-wifi-setup/blob/bugfix/mimic2_mycroft_utterance/dialog/en-us/device.not.connected.dialog)
