### PR TITLE
Fixes #42, apostrophes in SSIDs cause scan to exit with an exception

### DIFF
--- a/wifisetup/wifi_client.py
+++ b/wifisetup/wifi_client.py
@@ -181,8 +181,9 @@ class WifiClient:
             if "x00" in cell.ssid:
                 continue  # ignore hidden networks
 
-            # Fix UTF-8 characters
-            ssid = literal_eval("b'" + cell.ssid + "'").decode('utf8')
+            # Fix UTF-8 characters (work around bugs in wifi lib, see #42)
+            ssid = cell.ssid.replace("'", "\\'")
+            ssid = literal_eval("b'" + ssid + "'").decode('utf8')
             quality = self.get_quality(cell.quality)
 
             # If there are duplicate network IDs (e.g. repeaters) only


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}

Fixes #42 (scan exits with an exception if there is an apostrophe in the ssid)

* Description of how to validate or test this PR

Work through mycroft-wifi-setup in the presence of a Wifi network with an SSID that includes an apostrophe in its name.